### PR TITLE
Fix authentication on server without passwords

### DIFF
--- a/server/authenticate.ts
+++ b/server/authenticate.ts
@@ -9,7 +9,7 @@ export default function(socket: SocketIO.Socket, next: Function) {
     try { auth = JSON.parse(authJSON); } catch (e) { /* Ignore */ }
   }
 
-  if (auth != null && auth.serverPassword === config.password && typeof auth.username === "string" && usernameRegex.test(auth.username)) {
+  if (auth != null && (auth.serverPassword === config.password || config.password.length === 0) && typeof auth.username === "string" && usernameRegex.test(auth.username)) {
     (<any>socket).username = auth.username;
   }
 


### PR DESCRIPTION
I found out that we can't log on a Superpowers server without password if we already have a auth cookie on the client. Turns out that on the server the auth.serverPassword is check to be equal to config.serverPassword even when this last is an empty string.

To fix that problem I added an OR condition that check if the server password is null in the case where a auth.serverPassword won't be equal to the config.serverPassword