### PR TITLE
Use full path instead of asset names. Fixes #97.

### DIFF
--- a/client/src/project/index.ts
+++ b/client/src/project/index.ts
@@ -862,10 +862,10 @@ function onTrashEntryClick() {
 
     if (entry.dependentAssetIds != null && entry.dependentAssetIds.length > 0) {
       const dependentAssetNames: string[] = [];
-      for (const usingId of entry.dependentAssetIds) dependentAssetNames.push(data.entries.byId[usingId].name);
+      for (const usingId of entry.dependentAssetIds) dependentAssetNames.push(data.entries.getPathFromId(usingId));
       /* tslint:disable:no-unused-expression */
       const promptString = SupClient.i18n.t("project:treeView.trash.warnBrokenDependency", {
-        entryName: entry.name, dependentEntryNames: dependentAssetNames.join(", ")
+        entryName: data.entries.getPathFromId(entry.id), dependentEntryNames: dependentAssetNames.join(", ")
       });
       const validateString = SupClient.i18n.t("common:actions.close");
       new SupClient.dialogs.InfoDialog(promptString, validateString, () => { checkNextEntry(); });


### PR DESCRIPTION
-added calls to getPathFromId to get the fullpaths of the entries in the dependency warning